### PR TITLE
增加代理支持，为设置界面的元素加上提示

### DIFF
--- a/GUI/requirements.txt
+++ b/GUI/requirements.txt
@@ -1,4 +1,4 @@
-requests
+requests[socks]
 beautifulsoup4
 pycryptodome
 PyQt6


### PR DESCRIPTION
增加设置界面的提示和代理功能，需要重新生成设置文件或者手动加入`{"proxy":""}`到配置文件
需要socks5代理支持则需要额外安装requests[socks]依赖