### PR TITLE
增加利用存储的UID完成登陆的功能

### DIFF
--- a/GUI/.gitignore
+++ b/GUI/.gitignore
@@ -6,3 +6,4 @@ answers.db*
 test
 themes
 lang
+*.bak

--- a/GUI/README.md
+++ b/GUI/README.md
@@ -17,3 +17,7 @@
 5. 回到抓包程序，这时应该有相当多的连接请求记录
 6. 在记录里面从上往下寻找一条目标地址为 <https://ssxx.univs.cn/cgi-bin/authorize/token/> 的GET请求记录，带有URL参数 t,uid,avatar,activity_id ,查看响应预览
 7. 预览应该为一个JSON文档，其中token和refresh_token为所需数据，填入程序设置界面对应位置即可。后面将想办法实现这一过程的自动化
+
+## UID获取方法
+
+在上面第 6 步的请求参数中uid参数的值就是所需的UID。有UID的情况下优先使用UID获取Token完成登陆  

--- a/GUI/main-gui.py
+++ b/GUI/main-gui.py
@@ -562,7 +562,7 @@ class SettingWindow(QDialog):
         self.setLayout(layout)
         self.setModal(True)
         self.setParent(parent)
-        self.resize(400,300)
+        self.resize(int(parent.size().width()*(600/1024)),int(parent.size().height()*(600/1024)))
         title=QLabel("设置")
         title.setStyleSheet(theme["title"])
         title.setAlignment(Qt.Alignment.AlignCenter)


### PR DESCRIPTION
需要更新配置文件，在配置文件的auth小节加入
```json
{
    "uid":""
}
```
使配置文件相关部分变为
```json
{
    "auth":{
        "token":"xxxxxx",
        "refresh_token":"xxxxxx",
        "uid":""
    }
}
```
的形式
或者直接删除配置文件，重新生成一份。。。
也许应该写一个自动更新旧版配置的功能（
同时每次提交题目完成时将判断Token是否接近过期并自动更新即将过期的Token